### PR TITLE
close connection on invalid request

### DIFF
--- a/lib/src/HttpServer.cc
+++ b/lib/src/HttpServer.cc
@@ -208,7 +208,9 @@ void HttpServer::onMessage(const TcpConnectionPtr &conn, MsgBuffer *buf)
             buf->retrieveAll();
             // NOTE: should we call conn->forceClose() instead?
             // Calling shutdown() handles socket more elegantly.
-            conn->shutdown();
+            //conn->shutdown();
+            // force to close this connection to avoid too many connection error
+            conn->forceClose();
             // We have to call clearContext() here in order to ignore following
             // illegal data from client
             conn->clearContext();


### PR DESCRIPTION
close the connection forcefully if we receive an invalid request. As shutdown will cause the connection cannot be closed and trigger the too many connection errors if connection count exceeds the uplimit.